### PR TITLE
chore: Update requirements and README

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -83,6 +83,10 @@ INSTALLED_APPS = [
     'djangocms_frontend.contrib.image',
     'djangocms_frontend.contrib.tabs',
     'djangocms_frontend.contrib.utilities',
+
+    # test blog feature
+    'djangocms_blog',
+
 ]
 
 MIDDLEWARE = [
@@ -232,3 +236,11 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 CMS_CONFIRM_VERSION4 = True
 DJANGOCMS_VERSIONING_ALLOW_DELETING_VERSIONS = True
+
+# test blog feature
+BLOG_AUTO_SETUP = True # Set to False after setup (minimize overhead)
+BLOG_AUTO_HOME_TITLE ='Home'
+BLOG_AUTO_BLOG_TITLE = 'News'
+BLOG_AUTO_APP_TITLE = 'News'
+BLOG_AUTO_NAMESPACE = 'News'
+BLOG_ENABLE_COMMENTS = False

--- a/requirements.in
+++ b/requirements.in
@@ -28,6 +28,8 @@ djangocms-transfer>=2.0.0
 # optional django CMS frontend
 djangocms-frontend
 
+# test blog feature
+djangocms-blog
 django-filer
 
 


### PR DESCRIPTION
I try to test latest DjangoCMS blog on DjangoCMS Quick Start, off of https://github.com/django-cms/django-cms-quickstart/pull/78 (as of https://github.com/django-cms/django-cms-quickstart/pull/78/changes/7e99deb2) via `docker compose web build`.

> [!CAUTION]
> Fails, at `docker compose web build` because `ModuleNotFoundError: No module named 'djangocms_blog'`.
>
> <details>
>
> ```sh
> ~/Code/_django_cms/django-cms-quickstart (docs/readme) % docker compose build web
> [+] Building 37.2s (12/12) FINISHED                                                                         
>  => [internal] load local bake definitions                                                             0.0s
>  => => reading from stdin 572B                                                                         0.0s
>  => [internal] load build definition from Dockerfile                                                   0.0s
>  => => transferring dockerfile: 345B                                                                   0.0s
>  => [internal] load metadata for docker.io/library/python:3.13                                         0.6s
>  => [internal] load .dockerignore                                                                      0.0s
>  => => transferring context: 72B                                                                       0.0s
>  => [1/7] FROM docker.io/library/python:3.13@sha256:c8b03b4e98b39cfb180a5ea13ae5ee39039a8f75ccf52fe6d  0.0s
>  => => resolve docker.io/library/python:3.13@sha256:c8b03b4e98b39cfb180a5ea13ae5ee39039a8f75ccf52fe6d  0.0s
>  => [internal] load build context                                                                      0.0s
>  => => transferring context: 40.41kB                                                                   0.0s
>  => CACHED [2/7] WORKDIR /app                                                                          0.0s
>  => CACHED [3/7] RUN python -m pip install --upgrade pip                                               0.0s
>  => [4/7] COPY requirements.txt .                                                                      0.0s
>  => [5/7] RUN python -m pip install --no-cache-dir -r requirements.txt                                34.7s
>  => [6/7] COPY . .                                                                                     0.3s
>  => ERROR [7/7] RUN python manage.py collectstatic --noinput                                           0.6s
> ------
>  > [7/7] RUN python manage.py collectstatic --noinput:
> 0.542 Traceback (most recent call last):
> 0.543   File "/app/manage.py", line 22, in <module>
> 0.543     main()
> 0.543     ~~~~^^
> 0.543   File "/app/manage.py", line 18, in main
> 0.543     execute_from_command_line(sys.argv)
> 0.543     ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
> 0.543   File "/usr/local/lib/python3.13/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
> 0.543     utility.execute()
> 0.543     ~~~~~~~~~~~~~~~^^
> 0.543   File "/usr/local/lib/python3.13/site-packages/django/core/management/__init__.py", line 416, in execute
> 0.543     django.setup()
> 0.543     ~~~~~~~~~~~~^^
> 0.543   File "/usr/local/lib/python3.13/site-packages/django/__init__.py", line 24, in setup
> 0.543     apps.populate(settings.INSTALLED_APPS)
> 0.543     ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
> 0.543   File "/usr/local/lib/python3.13/site-packages/django/apps/registry.py", line 91, in populate
> 0.543     app_config = AppConfig.create(entry)
> 0.543   File "/usr/local/lib/python3.13/site-packages/django/apps/config.py", line 193, in create
> 0.543     import_module(entry)
> 0.543     ~~~~~~~~~~~~~^^^^^^^
> 0.543   File "/usr/local/lib/python3.13/importlib/__init__.py", line 88, in import_module
> 0.543     return _bootstrap._gcd_import(name[level:], package, level)
> 0.543            ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 0.543   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
> 0.543   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
> 0.543   File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
> 0.544 ModuleNotFoundError: No module named 'djangocms_blog'
> ------
> [+] build 0/1
>  ⠙ Image django-cms-quickstart-web Building                                                           37.4s 
> Dockerfile:12
> 
> --------------------
> 
>   10 |     COPY . .
> 
>   11 |     
> 
>   12 | >>> RUN python manage.py collectstatic --noinput
> 
>   13 |     
> 
>   14 |     CMD uwsgi --http=0.0.0.0:80 --module=backend.wsgi
> 
> --------------------
> 
> failed to solve: process "/bin/sh -c python manage.py collectstatic --noinput" did not complete successfully: exit code: 1
> ```
>
> </details>